### PR TITLE
Support for yotta configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,10 +1,27 @@
 {
+  "appl_bootstrap_mode_thread": false,
+  "device_connector_uri": "\"coap:\/\/2607:f0d0:2601:52::20:5684\"",
   "mbed-os": {
     "net": {
       "stacks": {
          "lwip":false,
          "nanostack": true
       }
+    }
+  },
+  "mbed-mesh-api": {
+    "thread": {
+      "device_type": "\"Router\"",
+      "pollrate": 300,
+      "config": {
+        "channel_mask": "0x07fff800",
+        "channel_page": 0,
+        "channel": 12
+      }
+    },
+    "6lowpan_nd": {
+      "channel_mask": "0x1000",
+      "channel_page": 0
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "mbed-client": "^1.0.0",
     "atmel-rf-driver": "^2.0.0",
-    "mbed-mesh-api": "^2.0.0"
+    "mbed-mesh-api": "^2.1.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -29,9 +29,6 @@
 #include "mbed-mesh-api/AbstractMesh.h"
 #include "mbedclient.h"
 
-// Set bootstrap mode to be Thread, otherwise 6LOWPAN_ND is used
-//#define APPL_BOOTSTRAP_MODE_THREAD
-
 #define OBS_BUTTON      SW2
 #define UNREG_BUTTON    SW3
 
@@ -55,18 +52,17 @@ void app_start(int, char **)
     // by LWM2M Client API to communicate with mbed Device server.
     AbstractMesh *mesh_api;
     int8_t status;
-#ifdef APPL_BOOTSTRAP_MODE_THREAD
+#if (YOTTA_CFG_APPL_BOOTSTRAP_MODE_THREAD == true)
     mesh_api = MeshInterfaceFactory::createInterface(MESH_TYPE_THREAD);
     uint8_t eui64[8];
     int8_t rf_device_id = rf_device_register();
     // Read mac address after registering the device.
     rf_read_mac_address(&eui64[0]);
-    char *pskd = (char *)"Secret password";
-    status = ((MeshThread *)mesh_api)->init(rf_device_id, AbstractMesh::mesh_network_handler_t(mbedclient, &MbedClient::mesh_network_handler), eui64, pskd);
-#else /* APPL_BOOTSTRAP_MODE_THREAD */
+    status = ((MeshThread *)mesh_api)->init(rf_device_id, AbstractMesh::mesh_network_handler_t(mbedclient, &MbedClient::mesh_network_handler), eui64, NULL);
+#else /* YOTTA_CFG_APPL_BOOTSTRAP_MODE_THREAD */
     mesh_api = (Mesh6LoWPAN_ND *)MeshInterfaceFactory::createInterface(MESH_TYPE_6LOWPAN_ND);
     status = ((Mesh6LoWPAN_ND *)mesh_api)->init(rf_device_register(), AbstractMesh::mesh_network_handler_t(mbedclient, &MbedClient::mesh_network_handler));
-#endif /* APPL_BOOTSTRAP_MODE */
+#endif /* YOTTA_CFG_BOOTSTRAP_MODE_THREAD */
 
     if (status != MESH_ERROR_NONE) {
         printf("Mesh network initialization failed %d!\r\n", status);

--- a/source/mbedclient.cpp
+++ b/source/mbedclient.cpp
@@ -25,18 +25,11 @@
 
 using namespace mbed::util;
 
-
-// Enter ARM mbed Device Connector IPv6 address and Port number in
-// format coap://<IPv6 address>:PORT. If ARM mbed Device Connector IPv6 address
-// is 2607:f0d0:2601:52::20 then the URI is: "coap://2607:f0d0:2601:52::20:5684"
-const String &MBED_DEVICE_CONNECTOR_URI = "coap://2607:f0d0:2601:52::20:5684";
-
 const String &MANUFACTURER = "ARM";
 const String &TYPE = "type";
 const String &MODEL_NUMBER = "2015";
 const String &SERIAL_NUMBER = "12345";
 const uint8_t STATIC_VALUE[] = "Static value";
-
 
 MbedClient::MbedClient()
     : _led(LED3)
@@ -110,7 +103,7 @@ M2MSecurity *MbedClient::create_register_object()
     // required for client to connect to bootstrap server.
     M2MSecurity *security = M2MInterfaceFactory::create_security(M2MSecurity::M2MServer);
     if (security) {
-        security->set_resource_value(M2MSecurity::M2MServerUri, MBED_DEVICE_CONNECTOR_URI);
+        security->set_resource_value(M2MSecurity::M2MServerUri, YOTTA_CFG_DEVICE_CONNECTOR_URI);
         security->set_resource_value(M2MSecurity::BootstrapServer, 0);
         security->set_resource_value(M2MSecurity::SecurityMode, M2MSecurity::Certificate);
         security->set_resource_value(M2MSecurity::ServerPublicKey,SERVER_CERT,sizeof(SERVER_CERT));


### PR DESCRIPTION
Add basic nannostack configuration to config.json. No need to link
mbed-mesh-api anymore to make config changes.

@SeppoTakalo , please review