### PR TITLE
switch to get_stdio_serial

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -38,7 +38,7 @@
 static MbedClient *mbedclient;
 static InterruptIn *obs_button;
 static InterruptIn *unreg_button;
-static Serial pc(USBTX, USBRX);
+static Serial &pc = get_stdio_serial();
 
 void app_start(int, char **)
 {


### PR DESCRIPTION
@SeppoTakalo @anttiylitokola @artokin 

Could you check this? This would fix the serial tracing which was recently broken by an update to mbed-drivers libraries. It will still complain about yotta confict. 

Alternatively we could limit the mbed-drivers version to 0.11.8 which would clear the yotta errors also. This implementation has the advantage of being a bit newer and recommended implementation.