### PR TITLE
Adding implementation for get_random_number()

### DIFF
--- a/source/to_be_ported.c
+++ b/source/to_be_ported.c
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 void arm_random_module_init(void)
 {
@@ -24,4 +25,9 @@ void arm_random_module_init(void)
 uint32_t arm_random_seed_get(void)
 {
     return 0;
+}
+
+uint32_t get_random_number(void)
+{
+    return time(NULL);
 }


### PR DESCRIPTION
This is required by mbed-client-mbedtls module for application to
provide random number to mbedTLS functions.
